### PR TITLE
fix(task-scheduler): properly delete defendnot task on --disable (#45)

### DIFF
--- a/defendnot-loader/core/autorun.cpp
+++ b/defendnot-loader/core/autorun.cpp
@@ -42,19 +42,19 @@ namespace loader {
                 return false;
             }
 
-            hr = service->Connect(VARIANT{}, VARIANT{}, VARIANT{}, VARIANT{});
+            hr = service->Connect(_variant_t(), _variant_t(), _variant_t(), _variant_t());
             if (FAILED(hr)) {
                 return false;
             }
 
             com::Ptr<ITaskFolder> root_folder;
-            hr = service->GetFolder(BSTR(L"\\"), root_folder.ref_to_ptr());
+            hr = service->GetFolder(_bstr_t(L"\\"), root_folder.ref_to_ptr());
             if (FAILED(hr)) {
                 return false;
             }
 
             /// Cleanup our task, we will recreate it in the callback if needed
-            root_folder->DeleteTask(BSTR(kTaskName.data()), 0);
+            root_folder->DeleteTask(_bstr_t(kTaskName.data()), 0);
             return callback(service.get(), root_folder.get());
         }
     } // namespace


### PR DESCRIPTION
### Summary
This PR fixes an issue where the `defendnot` task was not being removed from the **root folder of the Windows Task Scheduler** after running with the `--disable` argument.  

---

### Changes
- Updated task deletion logic to ensure the scheduled task is fully removed.
- Verified cleanup occurs in the Task Scheduler root folder.

---

### Steps to Test
1. Run `defendnot --disable`.
2. Open **Windows Task Scheduler**.
3. Navigate to the **Task Scheduler Library (root folder)**.
4. Confirm that the `defendnot` task is no longer present.

---

### Related Issue
Closes #45

---

### Checklist
- [x] Bug fix implemented
- [x] Tested on Windows 25H2